### PR TITLE
Reset git diff settings for color and mnemonicprefix to default

### DIFF
--- a/lib/rubocop/git/runner.rb
+++ b/lib/rubocop/git/runner.rb
@@ -33,7 +33,7 @@ module RuboCop
       end
 
       def git_diff(options)
-        args = %w(diff --diff-filter=AMCR --find-renames --find-copies)
+        args = %w(-c diff.mnemonicprefix=false diff --no-color --diff-filter=AMCR --find-renames --find-copies)
 
         args << '--cached' if options.cached
         if options.file


### PR DESCRIPTION
This is m4i#32 rebased for the NickLaMuro/all_the_features branch. I'd prefer if we eventually merge the whole all_the_features branch into master and go from there, should we need to apply other patches to our own fork.

I have run into this problem while trying to commit only Gemfile and Gemfile.lock changes. Follow the issue and the test to gain more context.

Pinging @skanev.